### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-01-19
+
+- Added new *ObjectPool* & *GameObjectPool* pools to allow to allow to use object pools independent from the *PoolService*. This allows to have different pools of the same type in the project in different object controllers
+- Added new interface *IPoolEntityClear* that allows a callback method for entities when they are cleared from the pool
+- Added new unit tests for the *ObjectPool*
+
+**Changed**:
+- Now the PoolService.Clear() does not take any action parameters. To have a callback when the entity is cleared, please have the entity implement the *IPoolEntityClear* interface
+
 ## [0.1.1] - 2020-01-06
 
 - Added License

--- a/Runtime/PoolService.cs
+++ b/Runtime/PoolService.cs
@@ -1,10 +1,117 @@
 using System;
 using System.Collections.Generic;
+using UnityEngine;
+using Object = UnityEngine.Object;
 
 // ReSharper disable once CheckNamespace
 
 namespace GameLovers.Services
 {
+	/// <summary>
+	/// This service allows to manage multiple pools of different types.
+	/// The service can only a single pool of the same type. 
+	/// </summary>
+	public interface IPoolService
+	{
+		/// <summary>
+		/// Initializes a new pool with the given <paramref name="initialSize"/>
+		/// It invokes the <paramref name="instantiator"/> function every time a new entity is created in the pool
+		/// </summary>
+		void InitPool<T>(int initialSize, Func<T> instantiator) where T : new();
+		
+		/// <summary>
+		/// Initializes a new pool with the given <paramref name="initialSize"/> and a sample entity given back in the <paramref name="instantiator"/>
+		/// It invokes the <paramref name="instantiator"/> function every time a new entity is created in the pool
+		/// </summary>
+		void InitPool<T>(int initialSize, T sampleEntity, Func<T, T> instantiator) where T : Object;
+
+		/// <summary>
+		/// Checks if exists a pool of the given type already exists or needs to be initialized with
+		/// <seealso cref="InitPool{T}(int,System.Func{T})"/>  before calling <seealso cref="Spawn{T}"/>
+		/// </summary>
+		bool HasPool<T>();
+
+		/// <inheritdoc cref="HasPool{T}"/>
+		bool HasPool(Type type);
+		
+		/// <inheritdoc cref="IObjectPool{T}.Spawn"/>
+		T Spawn<T>();
+		
+		/// <inheritdoc cref="IObjectPool{T}.Despawn"/>
+		void Despawn<T>(T entity);
+
+		/// <inheritdoc cref="IObjectPool{T}.DespawnAll"/>
+		void DespawnAll<T>();
+
+		/// <inheritdoc cref="IObjectPool{T}.Clear"/>
+		void Clear<T>();
+	}
+	
+	/// <inheritdoc />
+	public class PoolService : IPoolService
+	{
+		private readonly Dictionary<Type, IObjectPool> _pools = new Dictionary<Type, IObjectPool>();
+		
+		/// <inheritdoc />
+		public void InitPool<T>(int initialSize, Func<T> instantiator) where T : new()
+		{
+			_pools.Add(typeof(T), new ObjectPool<T>(initialSize, instantiator));
+		}
+
+		/// <inheritdoc />
+		public void InitPool<T>(int initialSize, T sampleEntity, Func<T, T> instantiator) where T : Object
+		{
+			_pools.Add(typeof(T), new GameObjectPool<T>(initialSize, sampleEntity, instantiator));
+		}
+
+		/// <inheritdoc />
+		public bool HasPool<T>()
+		{
+			return HasPool(typeof(T));
+		}
+
+		/// <inheritdoc />
+		public bool HasPool(Type type)
+		{
+			return _pools.ContainsKey(type);
+		}
+
+		/// <inheritdoc />
+		public T Spawn<T>()
+		{
+			return GetPool<T>().Spawn();
+		}
+
+		/// <inheritdoc />
+		public void Despawn<T>(T entity)
+		{
+			GetPool<T>().Despawn(entity);
+		}
+
+		/// <inheritdoc />
+		public void DespawnAll<T>()
+		{
+			GetPool<T>().DespawnAll();
+		}
+
+		/// <inheritdoc />
+		public void Clear<T>()
+		{
+			GetPool<T>().Clear();
+			_pools.Remove(typeof(T));
+		}
+
+		private IObjectPool<T> GetPool<T>()
+		{
+			if (!_pools.TryGetValue(typeof(T), out IObjectPool pool))
+			{
+				throw new ArgumentException("The pool was not initialized for the type " + typeof(T));
+			}
+
+			return pool as IObjectPool<T>;
+		}
+	}
+	
 	/// <summary>
 	/// This interface allows pooled objects to be notified when it is spawned
 	/// </summary>
@@ -28,183 +135,133 @@ namespace GameLovers.Services
 	}
 	
 	/// <summary>
-	/// Simple pool implementation that can handle any type of entity objects
+	/// This interface allows pooled objects to be notified when they are cleared from the pool
 	/// </summary>
-	public interface IPoolService
+	public interface IPoolEntityCleared
 	{
 		/// <summary>
-		/// Initializes a new pool with the given <paramref name="initialSize"/>
-		/// It invokes the <paramref name="instantiator"/> function every time a new entity is created in the pool
+		/// Invoked when the entity is cleared
 		/// </summary>
-		void InitPool<T>(int initialSize, Func<T> instantiator);
+		void OnCleared();
+	}
+
+	/// <summary>
+	/// Simple object pool implementation that can handle any type of entity objects
+	/// </summary>
+	public interface IObjectPool
+	{
+		/// <summary>
+		/// Clears the pool
+		/// This function does not clear the entity. For that, have the entity implement <see cref="IPoolEntityCleared"/> or do it externally
+		/// </summary>
+		void Clear();
 		
 		/// <summary>
-		/// Initializes a new pool with the given <paramref name="initialSize"/> and a sample entity given back in the <paramref name="instantiator"/>
-		/// It invokes the <paramref name="instantiator"/> function every time a new entity is created in the pool
+		/// Despawns all active spawned entities and returns them back to the pool to be used again later
+		/// This function does not reset the entity. For that, have the entity implement <see cref="IPoolEntityDespawn"/> or do it externally
 		/// </summary>
-		void InitPool<T>(int initialSize, T sampleEntity, Func<T, T> instantiator);
-
-		/// <summary>
-		/// Checks if exists a pool of the given type already exists or needs to be initialized with
-		/// <seealso cref="InitPool{T}(int,System.Func{T})"/>  before calling <seealso cref="Spawn{T}"/>
-		/// </summary>
-		bool HasPool<T>();
-
-		/// <inheritdoc cref="HasPool{T}"/>
-		bool HasPool(Type type);
-		
+		void DespawnAll();
+	}
+	
+	/// <inheritdoc />
+	public interface IObjectPool<T> : IObjectPool
+	{
 		/// <summary>
 		/// Spawns and returns an entity of the given type <typeparamref name="T"/>
 		/// This function does not initialize the entity. For that, have the entity implement <see cref="IPoolEntitySpawn"/> or do it externally
 		/// This function throws a <exception cref="StackOverflowException" /> if the pool is empty
 		/// </summary>
-		T Spawn<T>();
+		T Spawn();
 		
 		/// <summary>
 		/// Despawns the given <paramref name="entity"/> and returns it back to the pool to be used again later
 		/// This function does not reset the entity. For that, have the entity implement <see cref="IPoolEntityDespawn"/> or do it externally
 		/// </summary>
-		void Despawn<T>(T entity);
-
-		/// <summary>
-		/// Despawns all active spawned entities of the given type <typeparamref name="T"/> and returns them back to the pool to be used again later
-		/// This function does not reset the entity. For that, have the entity implement <see cref="IPoolEntityDespawn"/> or do it externally
-		/// </summary>
-		void DespawnAll<T>();
-
-		/// <summary>
-		/// Clears the pool of the given type <typeparamref name="T"/>
-		/// It calls <paramref name="clearAction"/> with every entity remaining in the pool and managed by the pool
-		/// </summary>
-		void Clear<T>(Action<T> clearAction);
+		void Despawn(T entity);
 	}
-	
+
 	/// <inheritdoc />
-	public class PoolService : IPoolService
+	public abstract class ObjectPoolBase<T> : IObjectPool<T>
 	{
-		private readonly Dictionary<Type, IPoolStack> pools = new Dictionary<Type, IPoolStack>();
+		private readonly Stack<T> _stack = new Stack<T>();
+		private readonly IList<T> _spawnedEntities = new List<T>();
+		private readonly Func<T, T> _instantiator;
+		private readonly T _sampleEntity;
+		
+		protected ObjectPoolBase(int initSize, T sampleEntity, Func<T, T> instantiator)
+		{
+			_sampleEntity = sampleEntity;
+			_instantiator = instantiator;
+			
+			for (var i = 0; i < initSize; i++)
+			{
+				_stack.Push(instantiator.Invoke(sampleEntity));
+			}
+		}
 		
 		/// <inheritdoc />
-		public void InitPool<T>(int initialSize, Func<T> instantiator)
+		public void Clear()
 		{
-			InitPool(initialSize, instantiator.Invoke(), newEntity => instantiator.Invoke());
-		}
-
-		/// <inheritdoc />
-		public void InitPool<T>(int initialSize, T sampleEntity, Func<T, T> instantiator)
-		{
-			if (pools.ContainsKey(typeof(T)))
+			for (var i = 0; i < _stack.Count; i++)
 			{
-				throw new InvalidOperationException($"The pool of type {typeof(T)} was already initialized");
+				var entity =_stack.Pop() as IPoolEntityCleared;
+				
+				entity?.OnCleared();
 			}
 			
-			var pool = new PoolStack<T>
-			{
-				Stack = new Stack<T>(), 
-				SpawnedEntities = new List<T>(),
-				SampleEntity = sampleEntity, 
-				Instatiator = instantiator
-			};
-			
-			pools.Add(typeof(T), pool);
-			
-			for (int i = 0; i < initialSize; i++)
-			{
-				pool.Stack.Push(instantiator.Invoke(sampleEntity));
-			}
+			_spawnedEntities.Clear();
 		}
 
 		/// <inheritdoc />
-		public bool HasPool<T>()
+		public T Spawn()
 		{
-			return HasPool(typeof(T));
-		}
-
-		/// <inheritdoc />
-		public bool HasPool(Type type)
-		{
-			return pools.ContainsKey(type);
-		}
-
-		/// <inheritdoc />
-		public T Spawn<T>()
-		{
-			var pool = GetPool<T>();
-			T entity = pool.Stack.Count == 0 ? pool.Instatiator.Invoke(pool.SampleEntity) : pool.Stack.Pop();
+			var entity = _stack.Count == 0 ? _instantiator.Invoke(_sampleEntity) : _stack.Pop();
 			var poolEntity = entity as IPoolEntitySpawn;
 			
-			pool.SpawnedEntities.Add(entity);
+			_spawnedEntities.Add(entity);
 			poolEntity?.OnSpawn();
-			
+
 			return entity;
 		}
 
 		/// <inheritdoc />
-		public void Despawn<T>(T entity)
+		public void Despawn(T entity)
 		{
-			var pool = GetPool<T>();
 			var poolEntity = entity as IPoolEntityDespawn;
 
-			pool.Stack.Push(entity);
-			pool.SpawnedEntities.Remove(entity);
+			_stack.Push(entity);
+			_spawnedEntities.Remove(entity);
 			poolEntity?.OnDespawn();
 		}
 
 		/// <inheritdoc />
-		public void DespawnAll<T>()
+		public void DespawnAll()
 		{
-			var pool = GetPool<T>();
-			
-			foreach (T entity in pool.SpawnedEntities)
+			for (var i = 0; i < _spawnedEntities.Count; i++)
 			{
-				var poolEntity = entity as IPoolEntityDespawn;
-
-				pool.Stack.Push(entity);
-				poolEntity?.OnDespawn();
+				Despawn(_spawnedEntities[i]);
 			}
-			
-			pool.SpawnedEntities.Clear();
+
+			_spawnedEntities.Clear();
 		}
+	}
 
-		/// <inheritdoc />
-		public void Clear<T>(Action<T> clearAction)
+	/// <inheritdoc />
+	public class ObjectPool<T> : ObjectPoolBase<T> where T : new()
+	{
+		public ObjectPool(int initSize, Func<T> instantiator) : base(initSize, instantiator(), newEntity => instantiator.Invoke())
 		{
-			var pool = GetPool<T>();
-
-			for (var i = 0; i < pool.Stack.Count; i++)
-			{
-				T entity = pool.Stack.Pop();
-				
-				clearAction?.Invoke(entity);
-			}
-			
-			pool.SpawnedEntities.Clear();
-			pools.Remove(typeof(T));
 		}
+	}
 
-		private PoolStack<T> GetPool<T>()
+	/// <inheritdoc />
+	/// <remarks>
+	/// <see cref="IObjectPool"/> implementation for objects of type <see cref="Object"/>
+	/// </remarks>
+	public class GameObjectPool<T> : ObjectPoolBase<T> where T : Object
+	{
+		public GameObjectPool(int initSize, T sampleEntity, Func<T, T> instantiator) : base(initSize, sampleEntity, instantiator)
 		{
-			if (!pools.TryGetValue(typeof(T), out IPoolStack poolStack))
-			{
-				throw new ArgumentException("The pool was not initialized for the type " + typeof(T));
-			}
-
-			if (poolStack is PoolStack<T> pool)
-			{
-				return pool;
-			}
-			
-			throw new ArgumentException("The pool was not properly initialized for the type " + typeof(T));
-		}
-		
-		private interface IPoolStack {}
-
-		private class PoolStack<T> : IPoolStack
-		{
-			public Stack<T> Stack;
-			public List<T> SpawnedEntities;
-			public Func<T, T> Instatiator;
-			public T SampleEntity;
 		}
 	}
 }

--- a/Tests/Editor/MainInstallerTest.cs
+++ b/Tests/Editor/MainInstallerTest.cs
@@ -44,7 +44,7 @@ namespace GameLoversEditor.Services.Tests
 		[Test]
 		public void Resolve_NotBinded_ThrowsException()
 		{
-			Assert.Throws<ArgumentNotFoundException>(() => MainInstaller.Resolve<IInterface>());
+			Assert.Throws<ArgumentException>(() => MainInstaller.Resolve<IInterface>());
 		}
 	}
 }

--- a/Tests/Editor/ObjectPoolTest.cs
+++ b/Tests/Editor/ObjectPoolTest.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using GameLovers.Services;
+using NSubstitute;
+using NUnit.Framework;
+
+// ReSharper disable once CheckNamespace
+
+namespace GameLoversEditor.Services.Tests
+{
+	public class ObjectPoolTest
+	{
+		private ObjectPool<PoolableEntity> _pool;
+		private PoolableEntity _poolableEntity;
+		private int initialSize = 5;
+
+		public class PoolableEntity : IPoolEntitySpawn, IPoolEntityDespawn, IPoolEntityCleared
+		{
+			public void OnSpawn() {}
+			public void OnDespawn() {}
+			public void OnCleared() {}
+		}
+
+		[SetUp]
+		public void Init()
+		{
+			_pool = new ObjectPool<PoolableEntity>(initialSize, () => Substitute.For<PoolableEntity>());
+			_poolableEntity = Substitute.For<PoolableEntity>();
+		}
+
+		[Test]
+		public void Spawn_Successfully()
+		{
+			var newEntity = _pool.Spawn();
+			
+			newEntity.Received().OnSpawn();
+			
+			Assert.AreNotSame(_poolableEntity, newEntity);
+		}
+
+		[Test]
+		public void Spawn_EmptyPool_Successfully()
+		{
+			var pool = new ObjectPool<PoolableEntity>(initialSize, () => Substitute.For<PoolableEntity>());
+			
+			var newEntity = pool.Spawn();
+			
+			newEntity.Received().OnSpawn();
+			
+			Assert.AreNotSame(_poolableEntity, newEntity);
+		}
+
+		[Test]
+		public void Despawn_Successfully()
+		{
+			_pool.Despawn(_poolableEntity);
+			
+			_poolableEntity.Received().OnDespawn();
+		}
+
+		[Test]
+		public void DespawnAll_Successfully()
+		{
+			var entities = new List<PoolableEntity>();
+
+			for (int i = 0; i < initialSize; i++)
+			{
+				entities.Add(Substitute.For<PoolableEntity>());
+			}
+			
+			_pool.DespawnAll();
+
+			foreach (var entity in entities)
+			{
+				entity.Received().OnDespawn();
+			}
+		}
+
+		[Test]
+		public void Clear_Successfully()
+		{
+			_pool.Despawn(_poolableEntity);
+			_pool.Clear();
+			
+			_poolableEntity.Received().OnCleared();
+			
+			Assert.DoesNotThrow(() => _pool.Spawn());
+			Assert.DoesNotThrow(() => _pool.Despawn(_poolableEntity));
+		}
+
+		[Test]
+		public void Clear_Twice_NothingHappens()
+		{
+			_pool.Clear();
+			
+			Assert.DoesNotThrow(() => _pool.Clear());
+		}
+	}
+}

--- a/Tests/Editor/ObjectPoolTest.cs.meta
+++ b/Tests/Editor/ObjectPoolTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e5572d97c03ad4be8a5d0a16c3b9655f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.gamelovers.services",
   "displayName": "Services",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "unity": "2019.3",
   "description": "This package contains a set of services to ease the development of a basic game architecture. The services provided by this package are:\n\n- CoroutineService to control all coroutines with an end callback\n- PoolService to control all object pools by type\n- MessageBrokerService to help decoupled modules/systems to communicate with each other while maintaining the inversion of control principle\n- TimeService to have a precise control on the game's time (Unix, Unity or DateTime)\n- TickService to have a single control point on Unity update cycle\n- MainInstaller to have a simple dependency injection binding installer",
   "type": "library",


### PR DESCRIPTION
- Added new *ObjectPool* & *GameObjectPool* pools to allow to allow to use object pools independent from the *PoolService*. This allows to have different pools of the same type in the project in different object controllers
- Added new interface *IPoolEntityClear* that allows a callback method for entities when they are cleared from the pool
- Added new unit tests for the *ObjectPool*

**Changed**:
- Now the PoolService.Clear() does not take any action parameters. To have a callback when the entity is cleared, please have the entity implement the *IPoolEntityClear* interface
