### PR TITLE
0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.0] - 2020-02-09
+
+- Now the *MainInstaller* checks the object binding relationship in compile time
+- The *CoroutineService* no longer fails on null coroutines
+- Improved the *ObjectPools* helper classes with a now static global instatiator for game objects.
+
+**Changed**:
+- Now the *PoolService* is only a service container for objects pools and no longer creates/initializes new pools.
+- Removed *Pool.Clear* functionality. Use *DespawnAll* or delete the pool instead 
+
 ## [0.2.0] - 2020-01-19
 
 - Added new *ObjectPool* & *GameObjectPool* pools to allow to allow to use object pools independent from the *PoolService*. This allows to have different pools of the same type in the project in different object controllers
@@ -11,7 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added new unit tests for the *ObjectPool*
 
 **Changed**:
-- Now the PoolService.Clear() does not take any action parameters. To have a callback when the entity is cleared, please have the entity implement the *IPoolEntityClear* interface
+- Now the *PoolService.Clear()* does not take any action parameters. To have a callback when the entity is cleared, please have the entity implement the *IPoolEntityClear* interface
 
 ## [0.1.1] - 2020-01-06
 

--- a/Runtime/CoroutineService.cs
+++ b/Runtime/CoroutineService.cs
@@ -140,13 +140,18 @@ namespace GameLovers.Services
 		/// <inheritdoc />
 		public void StopCoroutine(Coroutine coroutine)
 		{
-			_serviceObject.ExternalStopCoroutine(coroutine);
+			if (coroutine == null)
+			{
+				return;
+			}
+			
+			_serviceObject?.ExternalStopCoroutine(coroutine);
 		}
 
 		/// <inheritdoc />
 		public void StopAllCoroutines()
 		{
-			_serviceObject.StopAllCoroutines();
+			_serviceObject?.StopAllCoroutines();
 		}
 
 		private static IEnumerator InternalCoroutine(IEnumerator routine, ICompleteCoroutine completed)

--- a/Runtime/MainInstaller.cs
+++ b/Runtime/MainInstaller.cs
@@ -22,18 +22,13 @@ namespace GameLovers.Services
 		/// <exception cref="ArgumentException">
 		/// Thrown if the given <paramref name="instance"/> doesn't implement <typeparamref name="T"/> interface
 		/// </exception>
-		public static void Bind<T>(object instance) where T : class
+		public static void Bind<T>(T instance) where T : class
 		{
 			var type = typeof(T);
 
 			if (!type.IsInterface)
 			{
 				throw new ArgumentException($"Cannot bind {instance} because {type} is not an interface");
-			}
-
-			if (!(instance is T))
-			{
-				throw new ArgumentException($"Cannot bind the given instance because it doesn't implement the {type} interface");
 			}
 
 			_bindings.Add(type, instance);

--- a/Runtime/TimeService.cs
+++ b/Runtime/TimeService.cs
@@ -51,11 +51,12 @@ namespace GameLovers.Services
 		float UnityTimeFromUnixTime(long time);
 	}
 
-	/// <summary>
+	/// <inheritdoc cref="ITimeService"/>
+	/// <remarks>
 	/// Manipulates the service's time.
 	/// This can be useful in cases where we want to speed up the game or to synchronize time with an outside source
-	/// </summary>
-	public interface ITimeManipulator
+	/// </remarks>
+	public interface ITimeManipulator : ITimeService
 	{
 		/// <summary>
 		/// Adds <paramref name="timeInSeconds"/> to the current game's clock.
@@ -70,7 +71,7 @@ namespace GameLovers.Services
 	}
 
 	/// <inheritdoc cref="ITimeService"/>
-	public class TimeService : ITimeService, ITimeManipulator
+	public class TimeService : ITimeManipulator
 	{
 		private static readonly DateTime UnixInitialTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 

--- a/Tests/Editor/MainInstallerTest.cs
+++ b/Tests/Editor/MainInstallerTest.cs
@@ -32,13 +32,7 @@ namespace GameLoversEditor.Services.Tests
 		[Test]
 		public void Bind_NotInterface_ThrowsException()
 		{
-			Assert.Throws<ArgumentException>(() => MainInstaller.Bind<Implementation>(new Implementation()));
-		}
-
-		[Test]
-		public void Bind_NotImplementing_ThrowsException()
-		{
-			Assert.Throws<ArgumentException>(() => MainInstaller.Bind<IInterface>(new int[0]));
+			Assert.Throws<ArgumentException>(() => MainInstaller.Bind(new Implementation()));
 		}
 
 		[Test]

--- a/Tests/Editor/ObjectPoolTest.cs
+++ b/Tests/Editor/ObjectPoolTest.cs
@@ -14,11 +14,10 @@ namespace GameLoversEditor.Services.Tests
 		private PoolableEntity _poolableEntity;
 		private int initialSize = 5;
 
-		public class PoolableEntity : IPoolEntitySpawn, IPoolEntityDespawn, IPoolEntityCleared
+		public class PoolableEntity : IPoolEntitySpawn, IPoolEntityDespawn
 		{
 			public void OnSpawn() {}
 			public void OnDespawn() {}
-			public void OnCleared() {}
 		}
 
 		[SetUp]
@@ -74,26 +73,6 @@ namespace GameLoversEditor.Services.Tests
 			{
 				entity.Received().OnDespawn();
 			}
-		}
-
-		[Test]
-		public void Clear_Successfully()
-		{
-			_pool.Despawn(_poolableEntity);
-			_pool.Clear();
-			
-			_poolableEntity.Received().OnCleared();
-			
-			Assert.DoesNotThrow(() => _pool.Spawn());
-			Assert.DoesNotThrow(() => _pool.Despawn(_poolableEntity));
-		}
-
-		[Test]
-		public void Clear_Twice_NothingHappens()
-		{
-			_pool.Clear();
-			
-			Assert.DoesNotThrow(() => _pool.Clear());
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.gamelovers.services",
   "displayName": "Services",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "unity": "2019.3",
   "description": "This package contains a set of services to ease the development of a basic game architecture. The services provided by this package are:\n\n- CoroutineService to control all coroutines with an end callback\n- PoolService to control all object pools by type\n- MessageBrokerService to help decoupled modules/systems to communicate with each other while maintaining the inversion of control principle\n- TimeService to have a precise control on the game's time (Unix, Unity or DateTime)\n- TickService to have a single control point on Unity update cycle\n- MainInstaller to have a simple dependency injection binding installer",
   "type": "library",


### PR DESCRIPTION
- Now the *MainInstaller* checks the object binding relationship in compile time
- The *CoroutineService* no longer fails on null coroutines
- Improved the *ObjectPools* helper classes with a now static global instatiator for game objects.

**Changed**:
- Now the *PoolService* is only a service container for objects pools and no longer creates/initializes new pools.
- Removed *Pool.Clear* functionality. Use *DespawnAll* or delete the pool instead 